### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/lib/rpc/Client.js
+++ b/lib/rpc/Client.js
@@ -1,6 +1,6 @@
 var StreamParser = require("./StreamParser"),
     util = require("util"),
-    uuid = require("node-uuid/uuid"),
+    uuid = require("uuid"),
     Promise = require("node-promise/promise").Promise;
 
 var Client = module.exports = function(/*Stream*/stream, /*Object*/options){

--- a/package.json
+++ b/package.json
@@ -2,20 +2,26 @@
   "name": "node-sandbox-ex",
   "version": "0.2.1",
   "description": "Advanced sandboxing library that allows communication between the sandbox and the parent process.",
-  "keywords": ["sandbox", "library", "child_process"],
+  "keywords": [
+    "sandbox",
+    "library",
+    "child_process"
+  ],
   "repository": "https://github.com/adversinc/node-sandbox",
   "author": "Dino Fabrello <dinofabrello@slbiz2life.com>",
   "dependencies": {
-    "node-uuid": "1.3.3",
     "node-promise": "0.5.4",
-    "underscore": "1.3.3"
+    "underscore": "1.3.3",
+    "uuid": "^3.0.0"
   },
   "devDependencies": {
-      "mocha": ">= 1.5.0"
+    "mocha": ">= 1.5.0"
   },
   "scripts": {
-      "test": "cd lib/; mocha; cd ..;"
+    "test": "cd lib/; mocha; cd ..;"
   },
   "main": "index",
-  "engines": { "node": ">= 0.6.0" }
+  "engines": {
+    "node": ">= 0.6.0"
+  }
 }


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.